### PR TITLE
Update to work with SF 5.1

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,7 @@
 use Symfony\Component\Console\Application;
 use SymfonyMongoDBDocumentMaker\GenerateCommand;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../../../../vendor/autoload.php';
 
 $application = new Application('Symfony MongoDB Document Maker', '1.0.1');
 $application->add(new GenerateCommand());

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=7.2",
-        "symfony/console": "^4.4",
+        "symfony/console": ">=4.4",
         "nayjest/str-case-converter": "^1.0"
     },
     "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Hi, and thanks for this command !

I tried it today but had couple of problems since I'm using Symfony 5.1. I had to change the dependency on `symfony/console` and modify the path in `bin/console`.

It would be wonderful to be able to use it from any folder, but i didn't check yet how it would be possible. Anyway, it's already great that you did it!

This PR is maybe not for merging since it would possibly break the compatibility with installs on SF4, but at least, i wanted to put it here so that people interested can see how to make it work on SF5.

Thanks again for your work!